### PR TITLE
Incorrect JSON Parameter Name in CourseRole Struct

### DIFF
--- a/moodle_api.go
+++ b/moodle_api.go
@@ -1159,7 +1159,7 @@ type CourseGroup struct {
 }
 
 type CourseRole struct {
-	Id        int64  `json:"id"`
+	Id        int64  `json:"roleid"`
 	Name      string `json:"name"`
 	ShortName string `json:"shortname"`
 }


### PR DESCRIPTION
First of all, I want to express my appreciation for your work on this incredible library. It has been instrumental in the development of my projects, and I'm truly grateful for the effort you've put into it.

--- 

I've encountered an issue with the core_enrol_get_enrolled_users API endpoint in the Moodle Web Services. The issue pertains to an inconsistency in the naming convention of the JSON parameters returned by this endpoint.


---- 

`/admin/webservice/documentation.php`

`core_enrol_get_enrolled_users `

![image](https://github.com/zaddok/moodle/assets/1004620/ac51c995-dc17-487d-8c57-bfb224ab3337)

